### PR TITLE
ปรับปรุง layout หน้าเรียกคิวแบบกลุ่ม

### DIFF
--- a/src/app/admin/display-queue-group/display-queue-group.component.html
+++ b/src/app/admin/display-queue-group/display-queue-group.component.html
@@ -107,7 +107,7 @@
                         || '-'}}</span>
                     </div>
                     <div class="col-md-3">
-                      <span class="font-weight-bold" style="letter-spacing: 5px; font-size: 8rem;">{{item.room_number
+                      <span class="font-weight-bold" style="letter-spacing: 5px; font-size: 7rem; color:yellow">{{item.room_number
                         || '-'}}</span>
                     </div>
                   </div>

--- a/src/app/admin/queue-caller-group/queue-caller-group.component.html
+++ b/src/app/admin/queue-caller-group/queue-caller-group.component.html
@@ -56,41 +56,33 @@
 
       <div class="card-body" style="padding-left:5px;padding-right:5px;padding-top: 10px;">
 
-        <div class="row">
+        <div class="btn-group d-flex" style="margin-bottom:5px;">
+          <button [disabled]="!waitingItems.length || !roomId" class="w-100 btn btn-sm btn-primary"
+            (click)="onCallQueueGroup(2)">
+            <span class="h4">
+              เรียก 2 คิว
+            </span>
+          </button>
 
-          <div class="col-md-1" style="vertical-align: middle;text-align: right;padding-right: 0%;">
-            <span>ค้นหา</span>
-          </div>
-          <div class="col-md-4" style="padding-right: 0%; padding-left: 5px;">
-            <input [disabled]="!servicePointId" type="text" class="form-control" [(ngModel)]="queryWaiting"
-              name="queryWaiting" (keyup)="searchQueryWaiting()">
-          </div>
-          <div class="col-md-7" style="padding-left: 0%; text-align: right">
-            <div class="btn-group">
-              <button [disabled]="!waitingItems.length || !roomId" class="btn btn-sm btn-primary"
-                (click)="onCallQueueGroup(2)">
-                <span class="h4">
-                  เรียก 2 คิว
-                </span>
-              </button>
+          <button [disabled]="!waitingItems.length || !roomId" class="w-100 btn btn-sm btn-primary"
+            (click)="onCallQueueGroup(3)">
+            <span class="h4">
+              เรียก 3 คิว
+            </span>
+          </button>
 
-              <button [disabled]="!waitingItems.length || !roomId" class="btn btn-sm btn-primary"
-                (click)="onCallQueueGroup(3)">
-                <span class="h4">
-                  เรียก 3 คิว
-                </span>
-              </button>
+          <button [disabled]="!waitingItems.length || !roomId" class="w-100 btn btn-sm btn-primary"
+            (click)="onCallQueueGroup(5)">
+            <span class="h4">
+              เรียก 5 คิว
+            </span>
+          </button>
 
-              <button [disabled]="!waitingItems.length || !roomId" class="btn btn-sm btn-primary"
-                (click)="onCallQueueGroup(5)">
-                <span class="h4">
-                  เรียก 5 คิว
-                </span>
-              </button>
-
-            </div>
-          </div>
         </div>
+        
+        <input [disabled]="!servicePointId" type="text" placeholder="ค้นหาด้วยชื่อ-นามสกุลหรือ HN" class="form-control" [(ngModel)]="queryWaiting"
+        name="queryWaiting" (keyup)="searchQueryWaiting()">
+    
         <table class="table">
           <thead>
             <tr>
@@ -107,6 +99,7 @@
             <tr *ngFor="let item of waitingItems">
               <td>
                 <span class="h3-x">{{item.title}}{{item.first_name}} {{item.last_name}}</span>
+                <p>HN: {{item.hn}}</p>
               </td>
               <td>
                 <span class="h3-x">{{item.priority_name}}</span>
@@ -145,7 +138,7 @@
   </div>
   <div class="col-md-6" style="padding-left:5px;padding-right:10px;padding-top:1px;">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header" style="min-height:68px;">
         <div class="row">
           <div class="col-md-12" style="margin:0px;">
             <span class="h3" style="padding-left:10px;">คิวที่กำลังเรียก
@@ -157,7 +150,7 @@
         </div>
       </div>
 
-      <div class="card-body" style="padding-left:5px;padding-right:5px;">
+      <div class="card-body" style="padding-left:5px;padding-right:5px;padding-top:5px;">
         <table class="table">
           <thead>
             <tr>


### PR DESCRIPTION
ขอเสนอปรับปรุง layout หน้าเรียกคิวแบบกลุ่มให้ขยายเต็ม เพื่อที่จะสามารถใช้งานได้ง่ายๆ และแก้ใขให้รองรับ resposive กรณีใช้มือถือเร่ียกคิวจะได้ใช้ง่ายขึ้น โดยอ้างอิงจาก issue https://github.com/mophos/queue-docker/issues/18
จากเดิม 
![Screen Shot 2562-03-14 at 23 25 13](https://user-images.githubusercontent.com/1027274/54374033-dbf58580-46b0-11e9-847f-6109bc62d03c.png)
โดยขอปรับเปลี่ยน 3 จุดดังนี้

- ปรับช่องค้นใหม่
- ปรับปุ่มเรียกคิวแบบกลุ่ม
- เพิ่ม HN ในรายการข้อมูลคิวรอเรียก
![Screen Shot 2562-03-14 at 23 21 56](https://user-images.githubusercontent.com/1027274/54374139-1828e600-46b1-11e9-889d-977b7caa3b7b.png)

กรณีในมือถือ
<img width="600" alt="Screen Shot 2562-03-14 at 23 26 04" src="https://user-images.githubusercontent.com/1027274/54374177-2ecf3d00-46b1-11e9-9483-dc1dc5ba6b62.png">

แก้ font-size ในหน้าจอแสดงคิวแบบกลุ่มเล็กลงนิดนึงเพราะมันตกไปคนละบรรทัดและเปลี่ยนสีช่องบริการให้เด่นขึ้น

![Screen Shot 2562-03-14 at 23 47 25](https://user-images.githubusercontent.com/1027274/54375698-20ceeb80-46b4-11e9-891a-61b92e14150e.png)
